### PR TITLE
Move Travis build to Qt 5.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ compiler: g++
 sudo: required
   
 before_install:
-  - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+  - sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y
   - sudo apt-get update
 
 install:
-  - sudo apt-get install qt58base qt58svg qt58charts-no-lgpl qt58xmlpatterns cppcheck
-  - source /opt/qt58/bin/qt58-env.sh
-  - /opt/qt58/bin/qmake PREFIX=/usr
+  - sudo apt-get install qt510base cppcheck
+  - source /opt/qt5*/bin/qt5*-env.sh
+  - /opt/qt5*/bin/qmake PREFIX=/usr
 
 script:
   - make


### PR DESCRIPTION
Сейчас сборка на сервере происходит под Qt 5.8. Однако мы пишем проект под Qt 5.9.5 и выше, при этом можем использовать возможности, которых еще не было в Qt 5.8. Именно поэтому логично перенастроить сборку на Qt 5.10.