### PR TITLE
Вынесение логики диалога со справкой в отдельный класс

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Multimedia REQUIRED)
 
 set(SOURCES main.cpp
-        game_core/mainwindow.cpp game_core/map.cpp
+        game_core/mainwindow.cpp game_core/about_dialog.cpp game_core/map.cpp
         movable_objects/boom.cpp movable_objects/bot.cpp
         movable_objects/cleverbot.cpp movable_objects/improvedbot.cpp
         movable_objects/movable.cpp movable_objects/rocket.cpp

--- a/game_core/about_dialog.cpp
+++ b/game_core/about_dialog.cpp
@@ -1,0 +1,25 @@
+#include "about_dialog.h"
+
+#include <QScroller>
+#include <QUrl>
+
+AboutDialog::AboutDialog(QWidget* parent)
+    : QDialog(parent),
+      layout_(new QVBoxLayout(this)),
+      html_widget_(new QTextBrowser(this)),
+      buttons_(new QDialogButtonBox(
+          QDialogButtonBox::Ok, Qt::Horizontal, this)) {
+  html_widget_->setSource(QUrl("qrc:/rules/rules.html"));
+  html_widget_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  html_widget_->setOpenExternalLinks(true);
+
+#ifdef Q_OS_ANDROID
+  html_widget_->setTextInteractionFlags(
+      Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
+  QScroller::grabGesture(html_widget_, QScroller::TouchGesture);
+#endif
+
+  layout_->addWidget(html_widget_);
+  layout_->addWidget(buttons_);
+  connect(buttons_, &QDialogButtonBox::accepted, this, &AboutDialog::accept);
+}

--- a/game_core/about_dialog.h
+++ b/game_core/about_dialog.h
@@ -1,0 +1,22 @@
+#ifndef GAME_CORE_ABOUT_DIALOG_H_
+#define GAME_CORE_ABOUT_DIALOG_H_
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QTextBrowser>
+#include <QVBoxLayout>
+
+class AboutDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  explicit AboutDialog(QWidget* parent = nullptr);
+  ~AboutDialog() override = default;
+
+ private:
+  QVBoxLayout* layout_;
+  QTextBrowser* html_widget_;
+  QDialogButtonBox* buttons_;
+};
+
+#endif  // GAME_CORE_ABOUT_DIALOG_H_

--- a/game_core/mainwindow.cpp
+++ b/game_core/mainwindow.cpp
@@ -3,6 +3,7 @@
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent),
       screen_timer_(new QLCDNumber(this)),
+      about_dialog_(new AboutDialog(this)),
       main_buttons_layout_(new QVBoxLayout()),
       new_game_button_(new QPushButton(tr("New game"), this)),
       pause_continue_button_(new QPushButton(tr("Pause"), this)),
@@ -61,7 +62,7 @@ MainWindow::MainWindow(QWidget* parent)
   connect(
       pause_continue_button_, SIGNAL(clicked()), this, SLOT(PauseOrContinue()));
   connect(settings_button_, SIGNAL(clicked()), this, SLOT(Settings()));
-  connect(about_button_, SIGNAL(clicked()), this, SLOT(About()));
+  connect(about_button_, SIGNAL(clicked()), this, SLOT(ExecAboutDialog()));
 
   for (int i = 0; i < charge_buttons_.size(); ++i) {
     charge_buttons_[i]->setSizePolicy(QSizePolicy(QSizePolicy::Expanding,
@@ -118,7 +119,6 @@ MainWindow::MainWindow(QWidget* parent)
 
   InitializeNewGameDialog();
   InitializeSettingsDialog();
-  InitializeAboutDialog();
 
   timer_duration_ = available_fps_options_[fps_option_].second;
 
@@ -432,11 +432,14 @@ void MainWindow::Settings() {
   DetermineCurrentSettings();
 }
 
-void MainWindow::About() {
+void MainWindow::ExecAboutDialog() {
   if (!paused_) PauseOrContinue();
 
 #ifdef Q_OS_ANDROID
-  about_dialog_->showMaximized();
+  about_dialog_->showFullScreen();
+#else
+  about_dialog_->resize(500, 500);
+  about_dialog_->show();
 #endif
 
   about_dialog_->exec();
@@ -1019,38 +1022,6 @@ void MainWindow::InitializeSettingsDialog() {
           SLOT(accept()));
 
   settings_dialog_->layout()->setSizeConstraint(QLayout::SetFixedSize);
-}
-
-void MainWindow::InitializeAboutDialog() {
-  about_dialog_ = new QDialog(this);
-  html_widget_ = new QTextBrowser(this);
-  html_widget_->setSource(QUrl("qrc:/rules/rules.html"));
-
-#ifdef Q_OS_ANDROID
-  AdjustFont(html_widget_);
-  html_widget_->setTextInteractionFlags(Qt::NoTextInteraction);
-  how_to_scroll_label_ =
-      new QLabel(tr("Tip: you can use two fingers to scroll the reference"));
-#endif
-
-  about_dialog_buttons_ =
-      new QDialogButtonBox(QDialogButtonBox::Ok, Qt::Horizontal, about_dialog_);
-
-  about_dialog_layout_ = new QVBoxLayout(about_dialog_);
-
-#ifdef Q_OS_ANDROID
-  about_dialog_layout_->addWidget(how_to_scroll_label_);
-#endif
-
-  about_dialog_layout_->addWidget(html_widget_);
-  about_dialog_layout_->addWidget(about_dialog_buttons_);
-
-  connect(about_dialog_buttons_, SIGNAL(accepted()), about_dialog_,
-          SLOT(accept()));
-
-  about_dialog_->setFixedSize(500, 500);
-  html_widget_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-  html_widget_->setOpenExternalLinks(true);
 }
 
 void MainWindow::DetermineCurrentSettings() {

--- a/game_core/mainwindow.h
+++ b/game_core/mainwindow.h
@@ -38,6 +38,7 @@
 #include <utility>
 #include <vector>
 
+#include "game_core/about_dialog.h"
 #include "game_core/map.h"
 #include "static_objects/objectonmap.h"
 #include "static_objects/portal.h"
@@ -75,8 +76,7 @@ class MainWindow : public QMainWindow {
   void PauseOrContinue();
   // Runs settings dialog and switches options inside it.
   void Settings();
-  // Runs about dialog.
-  void About();
+  void ExecAboutDialog();
 
   // Creates KeyEvent with specified key. It's used for virtual keys buttons.
   void PressVirtualKey(Qt::Key key);
@@ -145,9 +145,6 @@ class MainWindow : public QMainWindow {
   void InitializeSettingsDialog();
   // Initializes About dialog with necessary content. Runs once (!) in the
   // constructor of main window.
-  void InitializeAboutDialog();
-  // Updates variables which store settings state with the information from
-  // settings file.
   void DetermineCurrentSettings();
   // Calls functions to change game settings according to variables state and
   // writes new info about settings to the settings file.
@@ -200,11 +197,7 @@ class MainWindow : public QMainWindow {
   QLabel* language_menu_label_;
   QLabel* language_menu_restart_label_;
 
-  QDialog* about_dialog_;
-  QDialogButtonBox* about_dialog_buttons_;
-  QVBoxLayout* about_dialog_layout_;
-  QTextBrowser* html_widget_;
-  QLabel* how_to_scroll_label_;
+  AboutDialog* about_dialog_;
 
   QVBoxLayout* main_buttons_layout_;
   QPushButton* new_game_button_;

--- a/game_core/mainwindow.h
+++ b/game_core/mainwindow.h
@@ -143,8 +143,8 @@ class MainWindow : public QMainWindow {
   // Initializes settings dialog with buttons and menus. Runs once (!) in the
   // constructor of main window.
   void InitializeSettingsDialog();
-  // Initializes About dialog with necessary content. Runs once (!) in the
-  // constructor of main window.
+  // Updates variables which store settings state with the information from
+  // settings file.
   void DetermineCurrentSettings();
   // Calls functions to change game settings according to variables state and
   // writes new info about settings to the settings file.

--- a/main.cpp
+++ b/main.cpp
@@ -68,9 +68,14 @@ int main(int argc, char* argv[]) {
   settings_file.write(new_json_string.toUtf8());
   settings_file.close();
 
-  MainWindow w;
-  w.setWindowTitle("Tanks");
-  w.show();
+  MainWindow main_window;
+  main_window.setWindowTitle("Tanks");
+
+#ifdef Q_OS_ANDROID
+  main_window.showFullScreen();
+#else
+  main_window.show();
+#endif
 
   return QApplication::exec();
 }

--- a/resources/rules/rules.html
+++ b/resources/rules/rules.html
@@ -18,7 +18,7 @@
         game, learn about management features and clarify information
         about objects on the map.
     </h3>
-    <h4>Version 0.8.1.0</h4>
+    <h4>Version 0.8.3.0</h4>
     <h3>
         This project was developed by <a href="https://github.com/Lessyless">
             Alesia Taraikovich </a>, <a href="https://github.com/sashhrmz">

--- a/tanks.pro
+++ b/tanks.pro
@@ -24,6 +24,7 @@ DISTFILES += \
 
 SOURCES += \
     main.cpp \
+    game_core/about_dialog.cpp \
     game_core/mainwindow.cpp \
     game_core/map.cpp \
     static_objects/objectonmap.cpp \
@@ -37,6 +38,7 @@ SOURCES += \
     movable_objects/tank.cpp
 
 HEADERS += \
+    game_core/about_dialog.h \
     game_core/mainwindow.h \
     game_core/map.h \
     static_objects/objectonmap.h \


### PR DESCRIPTION
Создан отдельный класс AboutDialog (наследник QDialog), который теперь используется для отображения справки по игре. Соответствующая логика по настройке диалога перенесена из класса MainWindow в класс AboutDialog.