### PR TITLE
Исправления для Android-версии игры

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-cpplint_light.py
 **/tanks.pro.user*
 .idea/
-cmake-build-debug/
-cmake-build-release/
-cmake-build-qt/
+cmake-build-*/
+.gradle/
+signing_config.gradle
+tanks.keystore

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,58 +1,79 @@
-<?xml version="1.0"?>
-<manifest package="org.tanks.tanks" xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionName="0.8.5" android:versionCode="9"
-    android:installLocation="auto">
-    <supports-screens android:largeScreens="true"
-        android:normalScreens="true" android:anyDensity="true"
-        android:smallScreens="true" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <application android:name="org.qtproject.qt5.android.bindings.QtApplication"
-        android:label="Tanks" android:icon="@drawable/icon"
-        android:isGame="true" android:hardwareAccelerated="true">
+<?xml version='1.0' encoding='utf-8'?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.github.tanks"
+          android:installLocation="auto">
+
+    <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
+         Remove the comment if you do not require these default permissions. -->
+    <!-- %%INSERT_PERMISSIONS -->
+
+    <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
+         Remove the comment if you do not require these default features. -->
+    <!-- %%INSERT_FEATURES -->
+
+    <application
+            android:name="org.qtproject.qt5.android.bindings.QtApplication"
+            android:label="Tanks"
+            android:icon="@drawable/icon"
+            android:extractNativeLibs="true"
+            android:hardwareAccelerated="true"
+            android:isGame="true">
+
         <activity android:name="org.qtproject.qt5.android.bindings.QtActivity"
-            android:alwaysRetainTaskState="true"
-            android:resizeableActivity="false"
-            android:screenOrientation="userLandscape" android:label="Tanks">
+                  android:label="Tanks"
+                  android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
+                  android:launchMode="singleTop"
+                  android:resizeableActivity="false"
+                  android:screenOrientation="userLandscape">
+
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
             <meta-data android:name="android.app.lib_name"
-                android:value="Tanks" />
+                       android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
             <meta-data android:name="android.app.qt_sources_resource_id"
-                android:resource="@array/qt_sources" />
+                       android:resource="@array/qt_sources"/>
             <meta-data android:name="android.app.repository"
-                android:value="default" />
+                       android:value="default"/>
             <meta-data android:name="android.app.qt_libs_resource_id"
-                android:resource="@array/qt_libs" />
+                       android:resource="@array/qt_libs"/>
             <meta-data android:name="android.app.bundled_libs_resource_id"
-                android:resource="@array/bundled_libs" />
+                       android:resource="@array/bundled_libs"/>
             <meta-data android:name="android.app.bundle_local_qt_libs"
-                android:value="1" />
+                       android:value="-- %%BUNDLE_LOCAL_QT_LIBS%% --"/>
             <meta-data android:name="android.app.use_local_qt_libs"
-                android:value="1" />
+                       android:value="-- %%USE_LOCAL_QT_LIBS%% --"/>
             <meta-data android:name="android.app.libs_prefix"
-                android:value="/data/local/tmp/qt/" />
+                       android:value="/data/local/tmp/qt/"/>
             <meta-data android:name="android.app.load_local_libs_resource_id"
-                android:resource="@array/load_local_libs" />
+                       android:resource="@array/load_local_libs"/>
             <meta-data android:name="android.app.load_local_jars"
-                android:value="jar/QtAndroidBearer.jar:jar/QtAndroid.jar:jar/QtMultimedia.jar" />
+                       android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes"
-                android:value="org.qtproject.qt5.android.multimedia.QtMultimediaUtils" />
+                       android:value="-- %%INSERT_INIT_CLASSES%% --"/>
+
+            <!-- Used to specify custom system library path to run with local system libs -->
+            <!-- <meta-data android:name="android.app.system_libs_prefix" android:value="/system/lib/"/> -->
+
             <meta-data android:value="@string/ministro_not_found_msg"
-                android:name="android.app.ministro_not_found_msg" />
+                       android:name="android.app.ministro_not_found_msg"/>
             <meta-data android:value="@string/ministro_needed_msg"
-                android:name="android.app.ministro_needed_msg" />
+                       android:name="android.app.ministro_needed_msg"/>
             <meta-data android:value="@string/fatal_error_msg"
-                android:name="android.app.fatal_error_msg" />
+                       android:name="android.app.fatal_error_msg"/>
             <meta-data android:value="@string/unsupported_android_version"
-                android:name="android.app.unsupported_android_version" />
+                       android:name="android.app.unsupported_android_version"/>
+
             <meta-data android:name="android.app.background_running"
-                android:value="true" />
+                       android:value="false"/>
             <meta-data android:name="android.app.auto_screen_scale_factor"
-                android:value="false" />
+                       android:value="false"/>
             <meta-data android:name="android.app.extract_android_style"
-                android:value="default" />
+                       android:value="default"/>
         </activity>
+
     </application>
+
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,7 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
+apply from: './signing_config.gradle'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
@@ -35,8 +36,16 @@ android {
      *******************************************************/
 
     compileSdkVersion androidCompileSdkVersion.toInteger()
+    buildToolsVersion androidBuildToolsVersion
 
-    buildToolsVersion '29.0.2'
+    signingConfigs {
+        release {
+            storeFile file('./tanks.keystore')
+            storePassword project.ext.storePassword
+            keyAlias project.ext.keyAlias
+            keyPassword project.ext.keyPassword
+        }
+    }
 
     sourceSets {
         main {
@@ -51,18 +60,31 @@ android {
        }
     }
 
+    tasks.withType(JavaCompile) {
+        options.incremental = true
+    }
+
+    defaultConfig {
+        resConfigs 'en'
+        minSdkVersion = qtMinSdkVersion
+        targetSdkVersion = qtTargetSdkVersion
+
+        applicationId 'com.github.tanks'
+        versionName '0.8.6'
+        versionCode 10
+        // signingConfig signingConfigs.release
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     lintOptions {
         abortOnError false
     }
 
-    // Do not compress Qt binary resources file
     aaptOptions {
         noCompress 'rcc'
-    }
-
-    defaultConfig {
-        resConfig "en"
-        minSdkVersion = qtMinSdkVersion
-        targetSdkVersion = qtTargetSdkVersion
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx2048m
+org.gradle.caching=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,172 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
+}
+APP_ARGS=$(save "$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/game_core/mainwindow.cpp
+++ b/game_core/mainwindow.cpp
@@ -121,6 +121,20 @@ MainWindow::MainWindow(QWidget* parent)
   music_playlist_->addMedia(QUrl("qrc:/sounds/backgroundmusic4.mp3"));
   music_player_->setPlaylist(music_playlist_);
   music_player_->setVolume(50);
+
+  connect(qApp, &QApplication::applicationStateChanged, [this] {
+    if (qApp->applicationState() == Qt::ApplicationActive) {
+      if (music_player_->state() == QMediaPlayer::PausedState) {
+        music_player_->play();
+      }
+    }
+    if (qApp->applicationState() == Qt::ApplicationHidden ||
+        qApp->applicationState() == Qt::ApplicationSuspended) {
+      if (music_player_->state() == QMediaPlayer::PlayingState) {
+        music_player_->pause();
+      }
+    }
+  });
 }
 
 MainWindow::~MainWindow() {

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,6 @@
-﻿#include <QApplication>
+﻿#include <iostream>
+
+#include <QApplication>
 #include <QLibraryInfo>
 #include <QProcess>
 #include <QSettings>
@@ -7,6 +9,11 @@
 
 #include "game_core/constants.h"
 #include "game_core/mainwindow.h"
+
+#ifdef Q_OS_ANDROID
+#include <QtAndroidExtras>
+#include <QDateTime>
+#endif
 
 int main(int argc, char* argv[]) {
 #ifdef Q_OS_ANDROID
@@ -43,6 +50,21 @@ int main(int argc, char* argv[]) {
       QLibraryInfo::location(QLibraryInfo::TranslationsPath));
   QApplication::installTranslator(&internal_translator);
 
+#ifdef Q_OS_ANDROID
+  QtAndroid::runOnAndroidThread([] {
+    auto activity = QtAndroid::androidActivity();
+    auto window =
+        activity.callObjectMethod("getWindow", "()Landroid/view/Window;");
+    const int FLAG_KEEP_SCREEN_ON = 128;
+    window.callMethod<void>("addFlags", "(I)V", FLAG_KEEP_SCREEN_ON);
+
+    QAndroidJniEnvironment env;
+    if (env->ExceptionCheck()) {
+      env->ExceptionClear();
+    }
+  });
+#endif
+
   MainWindow main_window;
   main_window.setWindowTitle("Tanks");
 
@@ -53,14 +75,67 @@ int main(int argc, char* argv[]) {
 #endif
 
   int return_code = QApplication::exec();
-
-#ifdef Q_OS_ANDROID
-  return return_code;
-#endif
-
   if (return_code != constants::kApplicationRestartCode) {
     return return_code;
   }
 
-  return !QProcess::startDetached(QApplication::applicationFilePath(), {});
+#ifdef Q_OS_ANDROID
+  // Code after won't work for SDK >= 28/29
+  qDebug() << QtAndroid::androidSdkVersion();
+
+  QtAndroid::runOnAndroidThread([] {
+    auto activity = QtAndroid::androidActivity();
+
+    auto packageManager = activity.callObjectMethod(
+        "getPackageManager",
+        "()Landroid/content/pm/PackageManager;");
+
+    auto activityIntent = packageManager.callObjectMethod(
+        "getLaunchIntentForPackage",
+        "(Ljava/lang/String;)Landroid/content/Intent;",
+        activity.callObjectMethod("getPackageName",
+                                  "()Ljava/lang/String;").object());
+
+    auto pendingIntent = QAndroidJniObject::callStaticObjectMethod(
+        "android/app/PendingIntent",
+        "getActivity",
+        "(Landroid/content/Context;ILandroid/content/Intent;I)"
+        "Landroid/app/PendingIntent;",
+        activity.object(),
+        jint(0),
+        activityIntent.object(),
+        QAndroidJniObject::getStaticField<jint>("android/content/Intent",
+                                                "FLAG_ACTIVITY_CLEAR_TOP"));
+
+    auto alarmManager = activity.callObjectMethod(
+        "getSystemService",
+        "(Ljava/lang/String;)Ljava/lang/Object;",
+        QAndroidJniObject::getStaticObjectField(
+            "android/content/Context",
+            "ALARM_SERVICE",
+            "Ljava/lang/String;").object());
+
+    alarmManager.callMethod<void>(
+        "setExact",
+        "(IJLandroid/app/PendingIntent;)V",
+        QAndroidJniObject::getStaticField<jint>(
+            "android/app/AlarmManager", "RTC"),
+        jlong(QDateTime::currentMSecsSinceEpoch() + 100),
+        pendingIntent.object());
+
+    QAndroidJniEnvironment env;
+    if (env->ExceptionCheck()) {
+      env->ExceptionClear();
+    }
+  });
+
+  return 0;
+#else
+  QString executable_path = QApplication::applicationFilePath();
+  if (!QProcess::startDetached(executable_path, {})) {
+    std::cerr << "Starting a new process failed!" << std::endl;
+    return 1;
+  }
+  return 0;
+#endif
 }

--- a/resources/rules/rules.html
+++ b/resources/rules/rules.html
@@ -18,13 +18,13 @@
         game, learn about management features and clarify information
         about objects on the map.
     </h3>
-    <h4>Version 0.8.5</h4>
+    <h4>Version 0.8.6</h4>
     <h3>
         This project was developed by <a href="https://github.com/Lessyless">
             Alesia Taraikovich </a>, <a href="https://github.com/sashhrmz">
             Aliaksandra Harmaza </a>, <a href="https://github.com/anevero">
             Andrew Nevero </a>.<br>
-        BSU FAMCS 2019-2020
+        BSU FAMCS 2019-2021
     </h3>
     <a href="https://github.com/anevero/tanks">
         <h4> © Tanks </h4>

--- a/tanks.pro
+++ b/tanks.pro
@@ -71,4 +71,4 @@ TRANSLATIONS += \
 
 RC_ICONS = resources/app_icon.ico
 
-VERSION = 0.8.4.0
+VERSION = 0.8.6.0

--- a/tanks.pro
+++ b/tanks.pro
@@ -18,9 +18,12 @@ ANDROID_PACKAGE_SOURCE_DIR = $$PWD/android
 DISTFILES += \
     android/AndroidManifest.xml \
     android/build.gradle \
+    android/gradle.properties \
     android/gradle/wrapper/gradle-wrapper.jar \
     android/gradle/wrapper/gradle-wrapper.properties \
-    android-sources/res/values/libs.xml
+    android/gradlew \
+    android/gradlew.bat \
+    android/res/values/libs.xml
 
 SOURCES += \
     main.cpp \


### PR DESCRIPTION
- Манифест и скрипты сборки Gradle приведены в соответствие с форматом, который используется текущими версиями Qt и Android SDK. Теперь приложение можно успешно скомпилировать.
- Реализовано выставление activity флага *keepScreenOn*, а также возможность автоматического перезапуска приложения для смены языка (работает с Android API <=28, а также с Android API >= 29, если это предусмотрел разработчик прошивки).
- Исправлен баг с музыкой, которая продолжала играть даже при сворачивании игры на Android.